### PR TITLE
Improve Anfragentext

### DIFF
--- a/froide_food/utils.py
+++ b/froide_food/utils.py
@@ -36,7 +36,8 @@ PLZ_RE = re.compile(r"(\d{5}) ([\w -]+)")
 
 Q1 = (
     "1. Wann haben die beiden letzten lebensmittelrechtlichen "
-    "Betriebsüberprüfungen im folgenden Betrieb stattgefunden:"
+    "Betriebsüberprüfungen im folgenden Betrieb incl. seinen "
+    "Vorgängerbetrieben stattgefunden:"
 )
 Q2 = (
     "2. Kam es hierbei zu Beanstandungen? Falls ja, beantrage ich "


### PR DESCRIPTION
VIG Anfragen werden öfters abgelehnt weil es aufgrund eines Betreiberwechsels keine aktuellen Kontrollen gibt. Daher ist es sinnvoll auch die Vorgängerbetriebe mit anzufragen.

Häufig ist der Betreiberwechsel aber nicht relevant. Vor allem wenn es sich um nicht einfach zu bestehende Bauliche Mängel handelt. Oder der Betreiberwechsel 'nur' innerhalb der Familie war und der Betrieb effektiv unverändert weitergeführt wird. Auch bei einem Verkauf an Fremde ändert sich nicht automatisch die Hygiene im Betrieb.

Ich hatte das mal komplett bist vors Amtsgericht durchgespielt. Mehr Infos hier:
https://ca.rstenpresser.de/blag/2024/02/verklag-den-staat-betreiberwechsel-und-vig-anfragen/